### PR TITLE
feat: add central logger

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,3 +68,21 @@ This section has moved here: [https://facebook.github.io/create-react-app/docs/d
 ### `npm run build` fails to minify
 
 This section has moved here: [https://facebook.github.io/create-react-app/docs/troubleshooting#npm-run-build-fails-to-minify](https://facebook.github.io/create-react-app/docs/troubleshooting#npm-run-build-fails-to-minify)
+
+### Logging
+
+Debug messages are routed through `src/utils/logger.js`. By default, debug output
+is shown only when `NODE_ENV` is not `production`. To enable verbose logging in
+production, set the environment variable `DEBUG=true` before starting the app:
+
+```
+DEBUG=true npm start
+```
+
+Use the logger by importing from `./utils/logger.js`:
+
+```
+import * as logger from './utils/logger.js';
+logger.info('Something happened');
+logger.debug('Detailed info');
+```

--- a/src/FootballFieldCore.js
+++ b/src/FootballFieldCore.js
@@ -23,6 +23,7 @@ import { playerDataManager } from './PlayerDataManager.js';
 
 // Import MatchManager
 import { matchManager } from './MatchManager.js';
+import * as logger from './utils/logger.js';
 
 export class FootballFieldCore {
   constructor() {
@@ -68,7 +69,7 @@ export class FootballFieldCore {
         userControlled: isUserControlled,
         hasBeenModified: isUserControlled
       };
-      console.log("💾 Camera state saved:", {
+      logger.debug("💾 Camera state saved:", {
         position: this.cameraState.position,
         userControlled: isUserControlled,
         hasBeenModified: this.cameraState.hasBeenModified
@@ -94,7 +95,7 @@ export class FootballFieldCore {
         gameStateManager.setUserControlledCamera(true);
       }
       
-      console.log("🔄 Camera state restored:", {
+      logger.debug("🔄 Camera state restored:", {
         position: savedState.position,
         userControlled: savedState.userControlled
       });
@@ -103,7 +104,7 @@ export class FootballFieldCore {
       setCameraPosition(savedState.position);
       setCameraZoom(75 / savedState.fov);
     } else {
-      console.log("📍 Using default camera position (no user modifications)");
+      logger.debug("📍 Using default camera position (no user modifications)");
     }
   }
 
@@ -112,7 +113,7 @@ export class FootballFieldCore {
     // 🔥 DEBUG: Rozšířený debug helper s goal testing + NET TESTING
     window.debugPlayer = {
       showAttributes: () => {
-        console.log('📊 Current Player Attributes:', {
+        logger.debug('📊 Current Player Attributes:', {
           dataManager: playerDataManager.attributes,
           player: this.player?.attributes,
           calculated: {
@@ -127,26 +128,26 @@ export class FootballFieldCore {
         playerDataManager.attributes[category][attr] = value;
         if (this.player?.refreshAttributes) {
           this.player.refreshAttributes();
-          console.log(`✅ Set ${category}.${attr} = ${value}`);
+          logger.debug(`✅ Set ${category}.${attr} = ${value}`);
         }
       },
       // AI debug commands
       aiStatus: () => {
         if (window.aiController) {
-          console.log('🤖 AI Status:', window.aiController.getStats());
+          logger.debug('🤖 AI Status:', window.aiController.getStats());
         } else {
-          console.log('❌ No AI controller active');
+          logger.warn('❌ No AI controller active');
         }
       },
       aiDebug: (enabled) => {
         if (window.aiController) {
           window.aiController.setDebugMode(enabled);
-          console.log(`🤖 AI Debug mode: ${enabled ? 'ON' : 'OFF'}`);
+          logger.debug(`🤖 AI Debug mode: ${enabled ? 'ON' : 'OFF'}`);
         }
       },
       aiInfo: () => {
         if (window.currentAIOpponent) {
-          console.log('🤖 AI Opponent:', {
+          logger.debug('🤖 AI Opponent:', {
             name: window.currentAIOpponent.name,
             level: window.currentAIOpponent.level,
             overall: window.currentAIOpponent.overallRating,
@@ -157,7 +158,7 @@ export class FootballFieldCore {
       },
       // Match debug commands
       matchStatus: () => {
-        console.log('⚽ Match Status:', matchManager.getCurrentState());
+        logger.debug('⚽ Match Status:', matchManager.getCurrentState());
       },
       matchStart: () => {
         matchManager.startMatch();
@@ -176,7 +177,7 @@ export class FootballFieldCore {
         if (this.ball) {
           this.ball.resetPosition({ x: -19, y: 0.5, z: 0 });
           this.ball.velocity.set(-2, 0, 0); // Rychlost směrem do branky
-          console.log('⚽ Ball positioned in front of LEFT goal (player scores)');
+          logger.debug('⚽ Ball positioned in front of LEFT goal (player scores)');
         }
       },
       
@@ -185,7 +186,7 @@ export class FootballFieldCore {
         if (this.ball) {
           this.ball.resetPosition({ x: 19, y: 0.5, z: 0 });
           this.ball.velocity.set(2, 0, 0); // Rychlost směrem do branky
-          console.log('⚽ Ball positioned in front of RIGHT goal (AI scores)');
+          logger.debug('⚽ Ball positioned in front of RIGHT goal (AI scores)');
         }
       },
       
@@ -194,7 +195,7 @@ export class FootballFieldCore {
         if (this.ball) {
           this.ball.resetPosition({ x: -18, y: 0.5, z: 0 });
           this.ball.velocity.set(-3, 0, -1.5); // Směr na levou tyčku
-          console.log('⚽ Ball shot towards LEFT goal post');
+          logger.debug('⚽ Ball shot towards LEFT goal post');
         }
       },
       
@@ -203,7 +204,7 @@ export class FootballFieldCore {
         if (this.ball) {
           this.ball.resetPosition({ x: -18, y: 0.5, z: 0 });
           this.ball.velocity.set(-2, 1.5, 0); // Směr na břevno
-          console.log('⚽ Ball shot towards crossbar');
+          logger.debug('⚽ Ball shot towards crossbar');
         }
       },
       
@@ -215,7 +216,7 @@ export class FootballFieldCore {
           
           this.ball.resetPosition({ x: 0, y: 0.5, z: 0 });
           this.ball.velocity.set(velocityX, 0.2, Math.random() * 2 - 1);
-          console.log(`🚀 Power shot towards ${direction} goal!`);
+          logger.debug(`🚀 Power shot towards ${direction} goal!`);
         }
       },
       
@@ -230,45 +231,45 @@ export class FootballFieldCore {
       ballReset: () => {
         if (this.ball) {
           this.ball.resetPosition();
-          console.log('🔄 Ball reset to center');
+          logger.debug('🔄 Ball reset to center');
         }
       },
       
       // Test goal detection systému
       testGoalSystem: () => {
-        console.log('🧪 Testing goal system...');
+        logger.debug('🧪 Testing goal system...');
         
         // Test 1: Levá branka
         setTimeout(() => {
-          console.log('Test 1: Ball to left goal');
+          logger.debug('Test 1: Ball to left goal');
           window.debugPlayer.ballToLeftGoal();
         }, 1000);
         
         // Test 2: Pravá branka  
         setTimeout(() => {
-          console.log('Test 2: Ball to right goal');
+          logger.debug('Test 2: Ball to right goal');
           window.debugPlayer.ballToRightGoal();
         }, 4000);
         
         // Test 3: Collision test
         setTimeout(() => {
-          console.log('Test 3: Ball to left post');
+          logger.debug('Test 3: Ball to left post');
           window.debugPlayer.ballToLeftPost();
         }, 7000);
         
         // Test 4: Crossbar test
         setTimeout(() => {
-          console.log('Test 4: Ball to crossbar');
+          logger.debug('Test 4: Ball to crossbar');
           window.debugPlayer.ballToCrossbar();
         }, 10000);
         
-        console.log('⏳ Goal system test sequence started (13 seconds total)');
+        logger.debug('⏳ Goal system test sequence started (13 seconds total)');
       },
       
       // Kompletní goal info
       goalInfo: () => {
         if (this.ball && this.ball.goals) {
-          console.log('🥅 Goal System Info:', {
+          logger.debug('🥅 Goal System Info:', {
             leftGoal: this.ball.goals.left,
             rightGoal: this.ball.goals.right,
             ballPosition: {
@@ -289,7 +290,7 @@ export class FootballFieldCore {
         if (this.ball) {
           this.ball.resetPosition({ x: -19, y: 0.8, z: 0 });
           this.ball.velocity.set(-8, 0, 0); // Fast shot into back net
-          console.log('🕸️ Testing back net collision');
+          logger.debug('🕸️ Testing back net collision');
         }
       },
       
@@ -300,7 +301,7 @@ export class FootballFieldCore {
           const z = side === 'left' ? -2 : -2;
           this.ball.resetPosition({ x: x, y: 0.5, z: z });
           this.ball.velocity.set(0, 0, side === 'left' ? -3 : -3);
-          console.log(`🕸️ Testing ${side} side net collision`);
+          logger.debug(`🕸️ Testing ${side} side net collision`);
         }
       },
       
@@ -309,7 +310,7 @@ export class FootballFieldCore {
         if (this.ball) {
           this.ball.resetPosition({ x: -19, y: 1.8, z: 0 });
           this.ball.velocity.set(-2, -1, 0);
-          console.log('🕸️ Testing top net collision');
+          logger.debug('🕸️ Testing top net collision');
         }
       },
       
@@ -324,9 +325,9 @@ export class FootballFieldCore {
           if (targetNet) {
             const impactPoint = new THREE.Vector3(0, 0.8, 0);
             window.fieldUtils.animateNetWave(targetNet, impactPoint, intensity);
-            console.log(`🌊 Animated ${goalSide} ${netType} net with intensity ${intensity}`);
+            logger.debug(`🌊 Animated ${goalSide} ${netType} net with intensity ${intensity}`);
           } else {
-            console.log(`❌ Net not found: ${goalSide} ${netType}`);
+            logger.warn(`❌ Net not found: ${goalSide} ${netType}`);
           }
         }
       },
@@ -341,7 +342,7 @@ export class FootballFieldCore {
               window.fieldUtils.animateNetWave(net, impactPoint, intensity);
             }, index * 200); // Staggered animation
           });
-          console.log(`🌊 Animated all ${nets.length} nets`);
+          logger.debug(`🌊 Animated all ${nets.length} nets`);
         }
       },
       
@@ -349,7 +350,7 @@ export class FootballFieldCore {
       netInfo: () => {
         if (window.fieldUtils) {
           const nets = window.fieldUtils.getGoalNets();
-          console.log('🕸️ Net System Info:', {
+          logger.debug('🕸️ Net System Info:', {
             totalNets: nets.length,
             nets: nets.map(net => ({
               type: net.userData.netType,
@@ -359,83 +360,83 @@ export class FootballFieldCore {
             }))
           });
         } else {
-          console.log('❌ FieldUtils not available');
+          logger.warn('❌ FieldUtils not available');
         }
       },
       
       // Complete net testing sequence
       testNetSequence: () => {
-        console.log('🧪 Starting complete net testing sequence...');
+        logger.debug('🧪 Starting complete net testing sequence...');
         
         // Test 1: Back net collision
         setTimeout(() => {
-          console.log('Test 1: Back net collision');
+          logger.debug('Test 1: Back net collision');
           window.debugPlayer.testNetCollision();
         }, 1000);
         
         // Test 2: Left side net
         setTimeout(() => {
-          console.log('Test 2: Left side net collision');
+          logger.debug('Test 2: Left side net collision');
           window.debugPlayer.testSideNet('left');
         }, 4000);
         
         // Test 3: Right side net
         setTimeout(() => {
-          console.log('Test 3: Right side net collision');
+          logger.debug('Test 3: Right side net collision');
           window.debugPlayer.testSideNet('right');
         }, 7000);
         
         // Test 4: Top net
         setTimeout(() => {
-          console.log('Test 4: Top net collision');
+          logger.debug('Test 4: Top net collision');
           window.debugPlayer.testTopNet();
         }, 10000);
         
         // Test 5: Manual net animation
         setTimeout(() => {
-          console.log('Test 5: Manual net wave animation');
+          logger.debug('Test 5: Manual net wave animation');
           window.debugPlayer.animateAllNets(0.5);
         }, 13000);
         
-        console.log('⏳ Net testing sequence started (16 seconds total)');
+        logger.debug('⏳ Net testing sequence started (16 seconds total)');
       },
       
       // === STADIUM SAVE COMMANDS ===
       saveStadium: () => {
         const saved = playerDataManager.stadiumManager.saveStadium();
-        console.log(saved ? '✅ Stadium saved!' : '❌ Failed to save stadium');
+        logger.debug(saved ? '✅ Stadium saved!' : '❌ Failed to save stadium');
       },
       
       stadiumInfo: () => {
         const info = playerDataManager.getStadiumInfo();
-        console.log('🏟️ Stadium Info:', info);
-        console.log('💾 Unsaved changes:', info.hasUnsavedChanges);
-        console.log('📦 Elements:', playerDataManager.stadiumManager.mainStadium.elements.length);
+        logger.debug('🏟️ Stadium Info:', info);
+        logger.debug('💾 Unsaved changes:', info.hasUnsavedChanges);
+        logger.debug('📦 Elements:', playerDataManager.stadiumManager.mainStadium.elements.length);
       }
     };
     
-    console.log('💡 Goal Debug Helper loaded! Available commands:');
-    console.log('🎯 window.debugPlayer.ballToLeftGoal() - Test player goal');
-    console.log('🤖 window.debugPlayer.ballToRightGoal() - Test AI goal');  
-    console.log('🏒 window.debugPlayer.ballToLeftPost() - Test post collision');
-    console.log('🎳 window.debugPlayer.ballToCrossbar() - Test crossbar collision');
-    console.log('🚀 window.debugPlayer.ballPowerShot("left") - Power shot test');
-    console.log('📊 window.debugPlayer.ballStatus() - Ball debug info');
-    console.log('🧪 window.debugPlayer.testGoalSystem() - Automated test sequence');
-    console.log('🥅 window.debugPlayer.goalInfo() - Complete goal system info');
+    logger.debug('💡 Goal Debug Helper loaded! Available commands:');
+    logger.debug('🎯 window.debugPlayer.ballToLeftGoal() - Test player goal');
+    logger.debug('🤖 window.debugPlayer.ballToRightGoal() - Test AI goal');  
+    logger.debug('🏒 window.debugPlayer.ballToLeftPost() - Test post collision');
+    logger.debug('🎳 window.debugPlayer.ballToCrossbar() - Test crossbar collision');
+    logger.debug('🚀 window.debugPlayer.ballPowerShot("left") - Power shot test');
+    logger.debug('📊 window.debugPlayer.ballStatus() - Ball debug info');
+    logger.debug('🧪 window.debugPlayer.testGoalSystem() - Automated test sequence');
+    logger.debug('🥅 window.debugPlayer.goalInfo() - Complete goal system info');
     
-    console.log('\n🕸️ Net System Commands:');
-    console.log('🌊 window.debugPlayer.testNetCollision() - Test back net collision');
-    console.log('🌊 window.debugPlayer.testSideNet("left") - Test side net collision');  
-    console.log('🌊 window.debugPlayer.testTopNet() - Test top net collision');
-    console.log('🌊 window.debugPlayer.animateNet("left", "back", 0.5) - Manual net animation');
-    console.log('🌊 window.debugPlayer.animateAllNets(0.3) - Animate all nets');
-    console.log('🕸️ window.debugPlayer.netInfo() - Net system info');
-    console.log('🧪 window.debugPlayer.testNetSequence() - Complete net testing sequence');
+    logger.debug('\n🕸️ Net System Commands:');
+    logger.debug('🌊 window.debugPlayer.testNetCollision() - Test back net collision');
+    logger.debug('🌊 window.debugPlayer.testSideNet("left") - Test side net collision');  
+    logger.debug('🌊 window.debugPlayer.testTopNet() - Test top net collision');
+    logger.debug('🌊 window.debugPlayer.animateNet("left", "back", 0.5) - Manual net animation');
+    logger.debug('🌊 window.debugPlayer.animateAllNets(0.3) - Animate all nets');
+    logger.debug('🕸️ window.debugPlayer.netInfo() - Net system info');
+    logger.debug('🧪 window.debugPlayer.testNetSequence() - Complete net testing sequence');
     
-    console.log('\n💾 Stadium Commands:');
-    console.log('💾 window.debugPlayer.saveStadium() - Manually save stadium');
-    console.log('🏟️ window.debugPlayer.stadiumInfo() - Stadium info and unsaved changes');
+    logger.debug('\n💾 Stadium Commands:');
+    logger.debug('💾 window.debugPlayer.saveStadium() - Manually save stadium');
+    logger.debug('🏟️ window.debugPlayer.stadiumInfo() - Stadium info and unsaved changes');
   }
 
   // Create and initialize the football field
@@ -448,7 +449,7 @@ export class FootballFieldCore {
     
     if (!mountRef.current || (gameState !== 'playing' && gameState !== 'editor')) return null;
 
-    console.log("🚀 Core field initialization - saving camera state first");
+    logger.info("🚀 Core field initialization - saving camera state first");
 
     // SAVE camera state BEFORE cleanup (pokud existuje)
     if (this.sceneSetup?.camera && this.gameStateManager) {
@@ -527,28 +528,28 @@ export class FootballFieldCore {
           if (value) {
             // User just took control - mark as modified
             this.cameraState.hasBeenModified = true;
-            console.log("🎮 User took control - marking camera as modified");
+            logger.debug("🎮 User took control - marking camera as modified");
           }
         };
       } else {
-        console.log('⚠️ gameStateManager.setUserControlledCamera method not found');
+        logger.warn('⚠️ gameStateManager.setUserControlledCamera method not found');
       }
       
       // 🏟️ OPRAVENO: Načti hlavní stadion hráče
-      console.log('🏟️ Loading player\'s main stadium...');
+      logger.debug('🏟️ Loading player\'s main stadium...');
       playerDataManager.loadMainStadium().then(loadedElements => {
         if (loadedElements && loadedElements.length > 0) {
-          console.log(`✅ Loaded ${loadedElements.length} stadium elements from Firebase`);
+          logger.debug(`✅ Loaded ${loadedElements.length} stadium elements from Firebase`);
           stateSetters.setStadiumElements(loadedElements);
           
           // Vytvoř 3D objekty pro načtené elementy
           this.stadiumManager.createExistingElements(loadedElements);
         } else {
-          console.log('🆕 Starting with empty stadium');
+          logger.debug('🆕 Starting with empty stadium');
           // Nic nedělej - začni s prázdným stadionem
         }
       }).catch(error => {
-        console.error('❌ Failed to load stadium:', error);
+        logger.error('❌ Failed to load stadium:', error);
       });
     }
     
@@ -573,18 +574,18 @@ export class FootballFieldCore {
       
       // Nastav globální referenci pro preview!
       window.playerRef = playerRef;
-      console.log('✅ Global playerRef set for preview synchronization');
+      logger.debug('✅ Global playerRef set for preview synchronization');
       
       // OKAMŽITĚ REFRESH VZHLED podle PlayerDataManager
       if (this.player.refreshAppearance) {
         this.player.refreshAppearance();
-        console.log('✅ Player appearance synced with PlayerDataManager on creation');
+        logger.debug('✅ Player appearance synced with PlayerDataManager on creation');
       }
       
       // OKAMŽITĚ REFRESH ATRIBUTY podle PlayerDataManager
       if (this.player.refreshAttributes) {
         this.player.refreshAttributes();
-        console.log('✅ Player attributes synced with PlayerDataManager on creation');
+        logger.debug('✅ Player attributes synced with PlayerDataManager on creation');
       }
       
       // Nastav viditelnost hlavy podle počátečního pohledu
@@ -592,11 +593,11 @@ export class FootballFieldCore {
         this.player.setHeadVisible(!isFirstPerson);
       }
       
-      console.log("✅ Player created with custom appearance AND attributes from PlayerDataManager");
+      logger.debug("✅ Player created with custom appearance AND attributes from PlayerDataManager");
       
       // Pokud je offline match, vytvoř AI hráče
       if (currentAIOpponent) {
-        console.log("🤖 Creating AI player:", currentAIOpponent.name);
+        logger.debug("🤖 Creating AI player:", currentAIOpponent.name);
         
         // Vytvoř AI hráče pomocí stejné třídy FootballPlayer
         this.aiPlayer = new FootballPlayer(scene, { x: 0, y: 0, z: -8 }, true); // true = isAI
@@ -628,7 +629,7 @@ export class FootballFieldCore {
         // Globální reference pro debugging
         window.aiPlayerRef = this.aiPlayer;
         
-        console.log("✅ AI player created with OVR:", this.aiPlayer.getOverallRating());
+        logger.debug("✅ AI player created with OVR:", this.aiPlayer.getOverallRating());
         
         // Vytvoř AI Controller
         this.aiController = new AIController(
@@ -641,7 +642,7 @@ export class FootballFieldCore {
         
         window.aiController = this.aiController; // Pro debugging
         
-        console.log("🎮 AI Controller created for:", currentAIOpponent.name);
+        logger.debug("🎮 AI Controller created for:", currentAIOpponent.name);
         
         // Volitelně: Zapni debug mode pro vývoj
         if (process.env.NODE_ENV === 'development') {
@@ -675,7 +676,7 @@ export class FootballFieldCore {
       this.animationManager.addUpdateCallback('netAnimations', (deltaTime) => {
         window.fieldUtils.updateNetAnimations(deltaTime);
       });
-      console.log('✅ Net animations registered with AnimationManager');
+      logger.debug('✅ Net animations registered with AnimationManager');
     }
     
     this.animationManager.start();
@@ -731,7 +732,7 @@ export class FootballFieldCore {
 
   // Cleanup all resources
   dispose() {
-    console.log("🧹 Core cleanup started");
+    logger.info("🧹 Core cleanup started");
 
     // SAVE camera state BEFORE cleanup
     if (this.sceneSetup?.camera && this.gameStateManager) {
@@ -767,7 +768,7 @@ export class FootballFieldCore {
       // Vyčisti globální referenci
       if (window.playerRef) {
         window.playerRef = null;
-        console.log('🧹 Global playerRef cleaned up');
+        logger.debug('🧹 Global playerRef cleaned up');
       }
     }
     if (this.ball) {
@@ -782,7 +783,7 @@ export class FootballFieldCore {
     }
     if (window.aiPlayerRef) {
       window.aiPlayerRef = null;
-      console.log('🧹 AI player cleaned up');
+      logger.debug('🧹 AI player cleaned up');
     }
     
     // Cleanup AI controller
@@ -791,13 +792,13 @@ export class FootballFieldCore {
     }
     if (window.aiController) {
       window.aiController = null;
-      console.log('🧹 AI Controller cleaned up');
+      logger.debug('🧹 AI Controller cleaned up');
     }
     
     // 🔥 NOVÉ: Cleanup FieldUtils reference
     if (window.fieldUtils) {
       window.fieldUtils = null;
-      console.log('🧹 FieldUtils reference cleaned up');
+      logger.debug('🧹 FieldUtils reference cleaned up');
     }
     
     // Cleanup debug helper
@@ -829,6 +830,6 @@ export class FootballFieldCore {
     this.cameraController = null;
     this.gameStateManager = null;
 
-    console.log("✅ Core cleanup completed");
+    logger.info("✅ Core cleanup completed");
   }
 }

--- a/src/ManualCameraController.js
+++ b/src/ManualCameraController.js
@@ -1,5 +1,6 @@
 // src/ManualCameraController.js
 import { THREE } from './three.js';
+import * as logger from './utils/logger.js';
 
 export class ManualCameraController {
   constructor(camera, gameStateManager) {
@@ -61,7 +62,7 @@ export class ManualCameraController {
   validateCameraState() {
     // Zkontroluj pozici kamery
     if (!this.camera.position || isNaN(this.camera.position.x) || isNaN(this.camera.position.y) || isNaN(this.camera.position.z)) {
-      console.warn("Invalid camera position detected, resetting to default");
+      logger.warn("Invalid camera position detected, resetting to default");
       this.camera.position.set(this.defaultPosition.x, this.defaultPosition.y, this.defaultPosition.z);
     }
     
@@ -108,7 +109,7 @@ export class ManualCameraController {
     if (event.code === 'KeyC') {
       setManualCameraMode(!manualCameraMode);
       event.preventDefault();
-      console.log(`Ruční ovládání kamery: ${!manualCameraMode ? 'ZAPNUTO' : 'VYPNUTO'}`);
+      logger.info(`Ruční ovládání kamery: ${!manualCameraMode ? 'ZAPNUTO' : 'VYPNUTO'}`);
       return;
     }
     
@@ -116,14 +117,14 @@ export class ManualCameraController {
     if (!manualCameraMode) return;
     
     // Debug log pro detekci problému
-    console.log(`Manual camera key pressed: ${event.code}`);
+    logger.debug(`Manual camera key pressed: ${event.code}`);
     
     // Šipky pro pohyb
     if (['ArrowUp', 'ArrowDown', 'ArrowLeft', 'ArrowRight'].includes(event.code)) {
       // Pokud klávesa není již držená, začni měřit čas
       if (!this.pressedKeys.has(event.code)) {
         this.keyPressTime.set(event.code, Date.now());
-        console.log(`Started tracking ${event.code} at ${Date.now()}`);
+        logger.debug(`Started tracking ${event.code} at ${Date.now()}`);
       }
       this.pressedKeys.add(event.code);
       event.preventDefault();
@@ -140,7 +141,7 @@ export class ManualCameraController {
       }
       this.keyRepeatBlocked.add(event.code);
       
-      console.log("Zoom IN pressed");
+      logger.debug("Zoom IN pressed");
       this.zoomCamera(this.keyZoomSpeed);
       event.preventDefault();
       return;
@@ -154,7 +155,7 @@ export class ManualCameraController {
       }
       this.keyRepeatBlocked.add(event.code);
       
-      console.log("Zoom OUT pressed");
+      logger.debug("Zoom OUT pressed");
       this.zoomCamera(-this.keyZoomSpeed);
       event.preventDefault();
       return;
@@ -162,7 +163,7 @@ export class ManualCameraController {
     
     // R pro reset
     if (event.code === 'KeyR') {
-      console.log("Reset camera pressed");
+      logger.debug("Reset camera pressed");
       this.resetCamera();
       event.preventDefault();
       return;
@@ -176,20 +177,20 @@ export class ManualCameraController {
     if (gameState !== 'editor' || !manualCameraMode) return;
     
     // Debug log
-    console.log(`Manual camera key released: ${event.code}`);
+    logger.debug(`Manual camera key released: ${event.code}`);
     
     if (['ArrowUp', 'ArrowDown', 'ArrowLeft', 'ArrowRight'].includes(event.code)) {
       this.pressedKeys.delete(event.code);
       // Vymaž čas držení klávesy
       this.keyPressTime.delete(event.code);
-      console.log(`Stopped tracking ${event.code}`);
+      logger.debug(`Stopped tracking ${event.code}`);
       event.preventDefault();
     }
     
     // Odblokuj zoom klávesy při puštění
     if (['Equal', 'NumpadAdd', 'Minus', 'NumpadSubtract'].includes(event.code)) {
       this.keyRepeatBlocked.delete(event.code);
-      console.log(`Unblocked key repeat for ${event.code}`);
+      logger.debug(`Unblocked key repeat for ${event.code}`);
       event.preventDefault();
     }
   }
@@ -201,7 +202,7 @@ export class ManualCameraController {
     if (gameState !== 'editor' || !manualCameraMode) return;
     
     // Debug log
-    console.log("Mouse wheel zoom:", event.deltaY);
+    logger.debug("Mouse wheel zoom:", event.deltaY);
     
     // Zoom kolečkem myši
     const zoomDelta = event.deltaY > 0 ? -this.zoomSpeed : this.zoomSpeed;
@@ -321,17 +322,17 @@ export class ManualCameraController {
     // Time-based throttling
     const currentTime = Date.now();
     if (currentTime - this.lastZoomTime < this.zoomThrottleMs) {
-      console.log("Zoom throttled");
+      logger.debug("Zoom throttled");
       return;
     }
     this.lastZoomTime = currentTime;
     
     // Debug log pro sledování zoom volání
-    console.log(`zoomCamera called with delta: ${zoomDelta}, current zoom: ${this.currentZoom}`);
+    logger.debug(`zoomCamera called with delta: ${zoomDelta}, current zoom: ${this.currentZoom}`);
     
     // Bezpečnostní kontrola delta
     if (!zoomDelta || isNaN(zoomDelta) || Math.abs(zoomDelta) > 1.0) {
-      console.warn("Invalid zoom delta:", zoomDelta);
+      logger.warn("Invalid zoom delta:", zoomDelta);
       return;
     }
     
@@ -349,12 +350,12 @@ export class ManualCameraController {
     this.camera.fov = Math.max(10, Math.min(120, newFOV));
     this.camera.updateProjectionMatrix();
     
-    console.log(`Camera zoom: ${this.currentZoom.toFixed(2)}x (FOV: ${this.camera.fov.toFixed(1)}°)`);
+    logger.debug(`Camera zoom: ${this.currentZoom.toFixed(2)}x (FOV: ${this.camera.fov.toFixed(1)}°)`);
   }
 
   // Reset kamery na výchozí pozici
   resetCamera() {
-    console.log("Resetuji kameru...");
+    logger.debug("Resetuji kameru...");
     
     // Vynucený reset pozice
     this.camera.position.set(
@@ -393,7 +394,7 @@ export class ManualCameraController {
     // Validace po resetu
     this.validateCameraState();
     
-    console.log("Kamera resetována:", {
+    logger.debug("Kamera resetována:", {
       position: this.camera.position,
       lookAt: this.currentLookAt,
       zoom: this.currentZoom,
@@ -404,18 +405,18 @@ export class ManualCameraController {
   // Zapnutí/vypnutí ruční kamery
   setManualMode(enabled) {
     if (enabled) {
-      console.log("Ruční ovládání kamery ZAPNUTO");
-      console.log("Ovládání:");
-      console.log("  ↑↓←→ = pohyb kamery");
-      console.log("  Tažení myší = změna směru pohledu");
-      console.log("  Kolečko/+/- = zoom");
-      console.log("  R = reset");
-      console.log("  C = vypnout");
+      logger.debug("Ruční ovládání kamery ZAPNUTO");
+      logger.debug("Ovládání:");
+      logger.debug("  ↑↓←→ = pohyb kamery");
+      logger.debug("  Tažení myší = změna směru pohledu");
+      logger.debug("  Kolečko/+/- = zoom");
+      logger.debug("  R = reset");
+      logger.debug("  C = vypnout");
       
       // Nastav kurzor aby indikoval možnost tažení
       document.body.style.cursor = 'grab';
     } else {
-      console.log("Ruční ovládání kamery VYPNUTO");
+      logger.debug("Ruční ovládání kamery VYPNUTO");
       // Vymaž stisknuté klávesy a časy
       this.pressedKeys.clear();
       this.keyPressTime.clear();

--- a/src/MatchManager.js
+++ b/src/MatchManager.js
@@ -1,5 +1,6 @@
 // src/MatchManager.js - Jednoduchý systém časomíry a skóre
 import { playerDataManager } from './PlayerDataManager.js';
+import * as logger from './utils/logger.js';
 
 class MatchManager {
   constructor() {
@@ -36,7 +37,7 @@ class MatchManager {
     this.celebrationDuration = 3000; // 3 sekundy oslava
     this.isInCelebration = false;
     
-    console.log('⚽ MatchManager initialized - 1 minute match ready!');
+    logger.info('⚽ MatchManager initialized - 1 minute match ready!');
     MatchManager.instance = this;
   }
   
@@ -44,7 +45,7 @@ class MatchManager {
   
   startMatch() {
     if (this.matchState === 'ended') {
-      console.log('❌ Cannot start - match already ended');
+      logger.warn('❌ Cannot start - match already ended');
       return false;
     }
     
@@ -52,7 +53,7 @@ class MatchManager {
     this.isPaused = false;
     this.matchState = 'playing';
     
-    console.log('🚀 Match started! Duration: 1 minute');
+    logger.info('🚀 Match started! Duration: 1 minute');
     this.notifyListeners('stateChange', { 
       state: 'playing', 
       time: this.currentTime,
@@ -68,7 +69,7 @@ class MatchManager {
     this.isPaused = true;
     this.matchState = 'paused';
     
-    console.log('⏸️ Match paused');
+    logger.info('⏸️ Match paused');
     this.notifyListeners('stateChange', { 
       state: 'paused', 
       time: this.currentTime,
@@ -84,7 +85,7 @@ class MatchManager {
     this.isPaused = false;
     this.matchState = 'playing';
     
-    console.log('▶️ Match resumed');
+    logger.info('▶️ Match resumed');
     this.notifyListeners('stateChange', { 
       state: 'playing', 
       time: this.currentTime,
@@ -107,7 +108,7 @@ class MatchManager {
       this.matchResult = 'draw';
     }
     
-    console.log(`🏁 Match ended! Result: ${this.matchResult}`, this.score);
+    logger.info(`🏁 Match ended! Result: ${this.matchResult}`, this.score);
     
     // PlayerData rewards
     this.giveMatchRewards();
@@ -136,14 +137,14 @@ class MatchManager {
     // Započítání gólu
     if (team === 'player') {
       this.score.player++;
-      console.log(`⚽ GÓL! Hráč skóroval! ${this.score.player}-${this.score.opponent}`);
+      logger.info(`⚽ GÓL! Hráč skóroval! ${this.score.player}-${this.score.opponent}`);
       
       // PlayerData reward
       playerDataManager.rewardGoal();
       
     } else if (team === 'opponent') {
       this.score.opponent++;
-      console.log(`😞 Soupeř skórował! ${this.score.player}-${this.score.opponent}`);
+      logger.info(`😞 Soupeř skórował! ${this.score.player}-${this.score.opponent}`);
     }
     
     // Notify listeners
@@ -156,7 +157,7 @@ class MatchManager {
     // Ukončení oslavy po 3 sekundách
     setTimeout(() => {
       this.isInCelebration = false;
-      console.log('🎉 Goal celebration ended');
+      logger.debug('🎉 Goal celebration ended');
     }, this.celebrationDuration);
     
     return true;
@@ -260,7 +261,7 @@ class MatchManager {
     this.isInCelebration = false;
     this.lastGoalTime = 0;
     
-    console.log('🔄 Match reset - ready for new game');
+    logger.info('🔄 Match reset - ready for new game');
     this.notifyListeners('stateChange', { 
       state: 'ready', 
       time: 0,
@@ -279,19 +280,19 @@ class MatchManager {
         playerDataManager.addCoins(baseCoins * 2, 'match_win');
         playerDataManager.addExperience(baseExp * 2, 'match_win');
         playerDataManager.stats.matchesWon++;
-        console.log('🏆 Victory rewards: +100 coins, +50 EXP');
+        logger.info('🏆 Victory rewards: +100 coins, +50 EXP');
         break;
         
       case 'draw':
         playerDataManager.addCoins(baseCoins, 'match_draw');
         playerDataManager.addExperience(baseExp, 'match_draw');
-        console.log('🤝 Draw rewards: +50 coins, +25 EXP');
+        logger.info('🤝 Draw rewards: +50 coins, +25 EXP');
         break;
         
       case 'lose':
         playerDataManager.addCoins(baseCoins / 2, 'match_participation');
         playerDataManager.addExperience(baseExp / 2, 'match_participation');
-        console.log('💪 Participation rewards: +25 coins, +12 EXP');
+        logger.info('💪 Participation rewards: +25 coins, +12 EXP');
         break;
     }
     
@@ -323,7 +324,7 @@ class MatchManager {
         try {
           callback(data);
         } catch (error) {
-          console.error(`Error in ${event} listener:`, error);
+          logger.error(`Error in ${event} listener:`, error);
         }
       });
     }
@@ -361,7 +362,7 @@ class MatchManager {
   // === DEBUG ===
   
   debugInfo() {
-    console.log('⚽ MatchManager Debug Info:', {
+    logger.debug('⚽ MatchManager Debug Info:', {
       time: `${this.currentTime.toFixed(1)}s / ${this.matchDuration}s`,
       formattedTime: this.getFormattedTime(),
       score: this.getScoreString(),

--- a/src/PlayerDataManager.js
+++ b/src/PlayerDataManager.js
@@ -7,6 +7,7 @@ import { PlayerFirebaseManager } from './PlayerDataManagerFirebase.js';
 import { PlayerProfileManager } from './PlayerDataManagerProfile.js';
 import { PlayerEventsManager } from './PlayerDataManagerEvents.js';
 import { PlayerStadiumManager } from './PlayerDataManagerStadium.js';
+import * as logger from './utils/logger.js';
 
 export class PlayerDataManager {
   constructor() {
@@ -15,7 +16,7 @@ export class PlayerDataManager {
       return PlayerDataManager.instance;
     }
     
-    console.log('🚀 Initializing PlayerDataManager v3.0 (Modular)...');
+    logger.info('🚀 Initializing PlayerDataManager v3.0 (Modular)...');
     
     // 🔔 Nejdříve event systém (ostatní managery ho potřebují)
     this.events = new PlayerEventsManager(this);
@@ -49,7 +50,7 @@ export class PlayerDataManager {
     // Inicializuj Firebase až po vytvoření všech managerů
     this.initializeFirebase();
     
-    console.log('✅ PlayerDataManager v3.0 initialized');
+    logger.info('✅ PlayerDataManager v3.0 initialized');
   }
   
   // Nastav cross-odkazy pro backward compatibility
@@ -132,7 +133,7 @@ export class PlayerDataManager {
     try {
       await this.firebaseManager.initialize();
     } catch (error) {
-      console.error('❌ Failed to initialize Firebase:', error);
+      logger.error('❌ Failed to initialize Firebase:', error);
     }
   }
   
@@ -281,14 +282,14 @@ export class PlayerDataManager {
         
         this.saveToFirebase();
         this.notifyListeners('dataImported', imported.data);
-        console.log('✅ Data successfully imported');
+        logger.info('✅ Data successfully imported');
         return true;
       } else {
-        console.error('❌ Invalid data format or version');
+        logger.error('❌ Invalid data format or version');
         return false;
       }
     } catch (error) {
-      console.error('❌ Failed to import data:', error);
+      logger.error('❌ Failed to import data:', error);
       return false;
     }
   }
@@ -325,14 +326,14 @@ export class PlayerDataManager {
   
   // 🧹 Cleanup
   dispose() {
-    console.log("🧹 Disposing PlayerDataManager...");
+    logger.info("🧹 Disposing PlayerDataManager...");
     
     // Dispose všech managerů
     this.firebaseManager?.dispose();
     this.events?.dispose();
     this.stadiumManager?.dispose();
     
-    console.log("✅ PlayerDataManager disposed");
+    logger.info("✅ PlayerDataManager disposed");
   }
   
   // 🛠️ Debug metody - kombinuj ze všech managerů
@@ -346,7 +347,7 @@ export class PlayerDataManager {
   // Debug info
   debugGetManagersInfo() {
     if (process.env.NODE_ENV === 'development') {
-      console.log('🛠️ DEBUG: Managers info:', {
+      logger.debug('🛠️ DEBUG: Managers info:', {
         economy: !!this.economy,
         attributes: !!this.attributesManager,
         customization: !!this.customizationManager,
@@ -406,4 +407,4 @@ if (typeof window !== 'undefined') {
   }
 }
 
-console.log('💾 PlayerDataManager v3.0 (Modular) initialized!');
+logger.info('💾 PlayerDataManager v3.0 (Modular) initialized!');

--- a/src/StadiumManager/StadiumManagerFirebaseSaveLoad.js
+++ b/src/StadiumManager/StadiumManagerFirebaseSaveLoad.js
@@ -1,5 +1,6 @@
 // src/StadiumManager/StadiumManagerFirebaseSaveLoad.js - 🔥 Firebase Save/Load System
 import { StadiumBuilder } from '../StadiumBuilder.js';
+import * as logger from '../utils/logger.js';
 
 export class StadiumManagerFirebaseSaveLoad {
   constructor(stadiumManager) {
@@ -17,10 +18,10 @@ export class StadiumManagerFirebaseSaveLoad {
       const checkFirebase = () => {
         if (window.firebaseManager && window.firebaseManager.getCurrentUser) {
           this.firebaseReady = true;
-          console.log('✅ Firebase ready for stadium saves');
+          logger.debug('✅ Firebase ready for stadium saves');
           resolve();
         } else {
-          console.log('⏳ Waiting for Firebase Manager...');
+          logger.debug('⏳ Waiting for Firebase Manager...');
           setTimeout(checkFirebase, 100);
         }
       };
@@ -35,7 +36,7 @@ export class StadiumManagerFirebaseSaveLoad {
 
   // 💾 SERIALIZACE - Převod stadium elementů na uložitelný formát
   serializeStadiumData(stadiumElements) {
-    console.log(`💾 Serializing ${stadiumElements.length} stadium elements...`);
+    logger.debug(`💾 Serializing ${stadiumElements.length} stadium elements...`);
     
     const serializedElements = stadiumElements.map(element => {
       const serialized = {
@@ -92,7 +93,7 @@ export class StadiumManagerFirebaseSaveLoad {
       }
     };
 
-    console.log(`✅ Serialization complete. Height map entries: ${heightMapData.length}`);
+    logger.debug(`✅ Serialization complete. Height map entries: ${heightMapData.length}`);
     return saveData;
   }
 
@@ -108,7 +109,7 @@ export class StadiumManagerFirebaseSaveLoad {
       if (!this.firebaseReady) await this.waitForFirebase();
       
       if (!this.isUserLoggedIn()) {
-        console.error('❌ Cannot save - user not logged in');
+        logger.error('❌ Cannot save - user not logged in');
         return false;
       }
 
@@ -134,10 +135,10 @@ export class StadiumManagerFirebaseSaveLoad {
         hasTerrainModifications: saveData.metadata.hasTerrainModifications
       });
 
-      console.log(`✅ Stadium saved as "${saveName}" to Firebase`);
+      logger.debug(`✅ Stadium saved as "${saveName}" to Firebase`);
       return true;
     } catch (error) {
-      console.error('❌ Error saving to Firebase:', error);
+      logger.error('❌ Error saving to Firebase:', error);
       return false;
     }
   }
@@ -148,7 +149,7 @@ export class StadiumManagerFirebaseSaveLoad {
       if (!this.firebaseReady) await this.waitForFirebase();
       
       if (!this.isUserLoggedIn()) {
-        console.error('❌ Cannot load - user not logged in');
+        logger.error('❌ Cannot load - user not logged in');
         return null;
       }
 
@@ -160,13 +161,13 @@ export class StadiumManagerFirebaseSaveLoad {
       const saveData = snapshot.val();
       
       if (!saveData) {
-        console.error(`❌ Save "${saveName}" not found`);
+        logger.error(`❌ Save "${saveName}" not found`);
         return null;
       }
 
       return this.deserializeStadiumData(saveData);
     } catch (error) {
-      console.error('❌ Error loading from Firebase:', error);
+      logger.error('❌ Error loading from Firebase:', error);
       return null;
     }
   }
@@ -177,7 +178,7 @@ export class StadiumManagerFirebaseSaveLoad {
       if (!this.firebaseReady) await this.waitForFirebase();
       
       if (!this.isUserLoggedIn()) {
-        console.log('⚠️ User not logged in');
+        logger.debug('⚠️ User not logged in');
         return {};
       }
 
@@ -188,10 +189,10 @@ export class StadiumManagerFirebaseSaveLoad {
       const snapshot = await firebaseManager.database.ref(stadiumListPath).once('value');
       const stadiumList = snapshot.val() || {};
       
-      console.log(`📋 Found ${Object.keys(stadiumList).length} saved stadiums`);
+      logger.debug(`📋 Found ${Object.keys(stadiumList).length} saved stadiums`);
       return stadiumList;
     } catch (error) {
-      console.error('❌ Error reading saves:', error);
+      logger.error('❌ Error reading saves:', error);
       return {};
     }
   }
@@ -202,7 +203,7 @@ export class StadiumManagerFirebaseSaveLoad {
       if (!this.firebaseReady) await this.waitForFirebase();
       
       if (!this.isUserLoggedIn()) {
-        console.error('❌ Cannot delete - user not logged in');
+        logger.error('❌ Cannot delete - user not logged in');
         return false;
       }
 
@@ -217,10 +218,10 @@ export class StadiumManagerFirebaseSaveLoad {
       const stadiumListPath = `users/${userId}/stadiumList/${saveName}`;
       await firebaseManager.database.ref(stadiumListPath).remove();
       
-      console.log(`✅ Save "${saveName}" deleted from Firebase`);
+      logger.debug(`✅ Save "${saveName}" deleted from Firebase`);
       return true;
     } catch (error) {
-      console.error('❌ Error deleting save:', error);
+      logger.error('❌ Error deleting save:', error);
       return false;
     }
   }
@@ -231,7 +232,7 @@ export class StadiumManagerFirebaseSaveLoad {
       if (!this.firebaseReady) await this.waitForFirebase();
       
       if (!this.isUserLoggedIn()) {
-        console.error('❌ Cannot share - user not logged in');
+        logger.error('❌ Cannot share - user not logged in');
         return null;
       }
 
@@ -261,10 +262,10 @@ export class StadiumManagerFirebaseSaveLoad {
       const sharePath = `sharedStadiums/${shareId}`;
       await firebaseManager.database.ref(sharePath).set(sharedStadium);
       
-      console.log(`✅ Stadium shared with ID: ${shareId}`);
+      logger.debug(`✅ Stadium shared with ID: ${shareId}`);
       return shareId;
     } catch (error) {
-      console.error('❌ Error sharing stadium:', error);
+      logger.error('❌ Error sharing stadium:', error);
       return null;
     }
   }
@@ -280,7 +281,7 @@ export class StadiumManagerFirebaseSaveLoad {
       const sharedData = snapshot.val();
       
       if (!sharedData) {
-        console.error(`❌ Shared stadium "${shareId}" not found`);
+        logger.error(`❌ Shared stadium "${shareId}" not found`);
         return null;
       }
 
@@ -289,17 +290,17 @@ export class StadiumManagerFirebaseSaveLoad {
       
       return this.deserializeStadiumData(sharedData);
     } catch (error) {
-      console.error('❌ Error loading shared stadium:', error);
+      logger.error('❌ Error loading shared stadium:', error);
       return null;
     }
   }
 
   // 🔄 DESERIALIZACE - Převod uložených dat zpět na stadium elementy
   deserializeStadiumData(saveData) {
-    console.log(`🔄 Deserializing save data...`);
+    logger.debug(`🔄 Deserializing save data...`);
     
     if (!saveData || !saveData.elements) {
-      console.error('❌ Invalid save data');
+      logger.error('❌ Invalid save data');
       return null;
     }
 
@@ -309,7 +310,7 @@ export class StadiumManagerFirebaseSaveLoad {
       saveData.heightMap.forEach(([key, value]) => {
         this.stadiumManager.heightMap.set(key, value);
       });
-      console.log(`✅ Restored ${saveData.heightMap.length} height map entries`);
+      logger.debug(`✅ Restored ${saveData.heightMap.length} height map entries`);
     }
 
     // 🏗️ Obnov elementy
@@ -352,7 +353,7 @@ export class StadiumManagerFirebaseSaveLoad {
       return element;
     });
 
-    console.log(`✅ Deserialized ${elements.length} elements`);
+    logger.debug(`✅ Deserialized ${elements.length} elements`);
     return {
       elements: elements,
       metadata: saveData.metadata
@@ -362,7 +363,7 @@ export class StadiumManagerFirebaseSaveLoad {
   // 🎮 APLIKOVAT NAČTENÁ DATA DO HRY
   applyLoadedData(loadedData, setStadiumElements) {
     if (!loadedData || !loadedData.elements) {
-      console.error('❌ No data to apply');
+      logger.error('❌ No data to apply');
       return false;
     }
 
@@ -377,12 +378,12 @@ export class StadiumManagerFirebaseSaveLoad {
       // Počkej na další frame a pak vytvoř mesh objekty
       requestAnimationFrame(() => {
         this.stadiumManager.utility.createExistingElements(loadedData.elements);
-        console.log(`✅ Stadium loaded successfully with ${loadedData.elements.length} elements`);
+        logger.debug(`✅ Stadium loaded successfully with ${loadedData.elements.length} elements`);
       });
 
       return true;
     } catch (error) {
-      console.error('❌ Error applying loaded data:', error);
+      logger.error('❌ Error applying loaded data:', error);
       return false;
     }
   }
@@ -418,7 +419,7 @@ export class StadiumManagerFirebaseSaveLoad {
       }
     }
     
-    console.log('❌ No quicksaves found');
+    logger.debug('❌ No quicksaves found');
     return false;
   }
 
@@ -456,10 +457,10 @@ export class StadiumManagerFirebaseSaveLoad {
       
       URL.revokeObjectURL(url);
       
-      console.log(`✅ Stadium exported as ${link.download}`);
+      logger.debug(`✅ Stadium exported as ${link.download}`);
       return true;
     } catch (error) {
-      console.error('❌ Error exporting file:', error);
+      logger.error('❌ Error exporting file:', error);
       return false;
     }
   }
@@ -472,12 +473,12 @@ export class StadiumManagerFirebaseSaveLoad {
       
       // Kontrola verze
       if (saveData.version !== this.SAVE_VERSION) {
-        console.warn(`⚠️ Save version mismatch: ${saveData.version} vs ${this.SAVE_VERSION}`);
+        logger.warn(`⚠️ Save version mismatch: ${saveData.version} vs ${this.SAVE_VERSION}`);
       }
 
       return this.deserializeStadiumData(saveData);
     } catch (error) {
-      console.error('❌ Error importing from file:', error);
+      logger.error('❌ Error importing from file:', error);
       return null;
     }
   }
@@ -504,7 +505,7 @@ export class StadiumManagerFirebaseSaveLoad {
       
       return stadiums.reverse(); // Nejvíc likes první
     } catch (error) {
-      console.error('❌ Error getting top stadiums:', error);
+      logger.error('❌ Error getting top stadiums:', error);
       return [];
     }
   }

--- a/src/StadiumManager/StadiumManagerPreview.js
+++ b/src/StadiumManager/StadiumManagerPreview.js
@@ -1,5 +1,6 @@
 // src/StadiumManager/StadiumManagerPreview.js - 🎯 PREVIEW SYSTEM
 import { THREE } from '../three.js';
+import * as logger from '../utils/logger.js';
 import { StadiumBuilder } from '../StadiumBuilder.js';
 
 export class StadiumManagerPreview {
@@ -66,7 +67,7 @@ export class StadiumManagerPreview {
     // Aplikuj rotaci přímo na Three.js objekt
     this.stadiumManager.previewObject.rotation.y = this.stadiumManager.previewRotation;
     
-    console.log(`Preview rotace: ${(this.stadiumManager.previewRotation * 180 / Math.PI).toFixed(0)}°`);
+    logger.debug(`Preview rotace: ${(this.stadiumManager.previewRotation * 180 / Math.PI).toFixed(0)}°`);
     
     return this.stadiumManager.previewRotation;
   }
@@ -122,7 +123,7 @@ export class StadiumManagerPreview {
         const valid = this.stadiumManager.validation.isValidPosition(intersection, stadiumElements, toolType);
         this.updatePreviewColor(newPreviewObj, valid);
         
-        console.log(`🎨 Terrain brush preview created: ${toolType} at (${intersection.x}, ${intersection.z}), current: ${currentHeight}m, change: ${heightChange}m`);
+        logger.debug(`🎨 Terrain brush preview created: ${toolType} at (${intersection.x}, ${intersection.z}), current: ${currentHeight}m, change: ${heightChange}m`);
         return { 
           position: intersection.clone(), 
           isValid: valid,
@@ -144,7 +145,7 @@ export class StadiumManagerPreview {
           const valid = this.stadiumManager.validation.isValidPosition(intersection, stadiumElements, toolType);
           this.updatePreviewColor(newPreviewObj, valid);
           
-          console.log(`Preview objekt vytvořen na pozici myši: ${toolType} (grid: ${gridSize}m)`);
+          logger.debug(`Preview objekt vytvořen na pozici myši: ${toolType} (grid: ${gridSize}m)`);
           return { position: intersection.clone(), isValid: valid };
         }
       }
@@ -277,7 +278,7 @@ export class StadiumManagerPreview {
         previousHeight: currentHeight
       };
       
-      console.log(`🎨 Terrain brush applied: ${selectedTool} at (${actualPosition.x.toFixed(1)}, ${actualPosition.z.toFixed(1)}) - Height: ${currentHeight.toFixed(1)}m → ${newHeight.toFixed(1)}m`);
+      logger.debug(`🎨 Terrain brush applied: ${selectedTool} at (${actualPosition.x.toFixed(1)}, ${actualPosition.z.toFixed(1)}) - Height: ${currentHeight.toFixed(1)}m → ${newHeight.toFixed(1)}m`);
       return newElement;
       
     } else {
@@ -300,7 +301,7 @@ export class StadiumManagerPreview {
           mesh: element
         };
         
-        console.log(`Postaveno: ${selectedTool} na pozici (${actualPosition.x.toFixed(1)}, ${actualPosition.z.toFixed(1)}) s rotací ${(this.stadiumManager.previewRotation * 180 / Math.PI).toFixed(0)}°`);
+        logger.debug(`Postaveno: ${selectedTool} na pozici (${actualPosition.x.toFixed(1)}, ${actualPosition.z.toFixed(1)}) s rotací ${(this.stadiumManager.previewRotation * 180 / Math.PI).toFixed(0)}°`);
         return newElement;
       }
     }

--- a/src/StadiumManager/StadiumManagerSeat.js
+++ b/src/StadiumManager/StadiumManagerSeat.js
@@ -1,5 +1,6 @@
 // src/StadiumManager/StadiumManagerSeat.js - 🪑 SEAT MANAGEMENT SYSTEM
 import { THREE } from '../three.js';
+import * as logger from '../utils/logger.js';
 import { StadiumBuilder } from '../StadiumBuilder.js';
 
 export class StadiumManagerSeat {
@@ -30,7 +31,7 @@ export class StadiumManagerSeat {
 
   // 🪑 Vytvoření preview sedačky
   createSeatPreview(seatType, seatColor) {
-    console.log(`🪑 Creating seat preview: ${seatType}, ${seatColor}`);
+    logger.debug(`🪑 Creating seat preview: ${seatType}, ${seatColor}`);
     
     const previewSeat = StadiumBuilder.createElement('individual_seat', { x: 0, y: 0, z: 0 }, {
       seatType: seatType,
@@ -39,7 +40,7 @@ export class StadiumManagerSeat {
     });
     
     if (!previewSeat) {
-      console.error('❌ Failed to create seat preview');
+      logger.error('❌ Failed to create seat preview');
       return null;
     }
     
@@ -61,7 +62,7 @@ export class StadiumManagerSeat {
       }
     });
     
-    console.log(`✅ Seat preview created successfully`);
+    logger.debug(`✅ Seat preview created successfully`);
     return previewSeat;
   }
 
@@ -91,7 +92,7 @@ export class StadiumManagerSeat {
 
   // 🪑 Vytvoření/aktualizace preview sedaček na pozici myši (MULTIPLE PREVIEW)
   updateSeatPreviewAtMousePosition(mouseScreen, camera, selectedStairs, seatOptions, stadiumElements) {
-    console.log(`🪑 Updating seat preview at mouse position`, { 
+    logger.debug(`🪑 Updating seat preview at mouse position`, { 
       placementMode: seatOptions.placementMode,
       seatType: seatOptions.type,
       seatColor: seatOptions.color
@@ -140,7 +141,7 @@ export class StadiumManagerSeat {
           !this.isPositionOccupied(pos.position, stadiumElements || [])
         );
         
-        console.log(`🪑 Preview positions: ${previewPositions.length} total, ${availablePositions.length} available`);
+        logger.debug(`🪑 Preview positions: ${previewPositions.length} total, ${availablePositions.length} available`);
         
         // Pokud se změnily options nebo počet pozic, vytvoř nové preview
         if (!this.stadiumManager.seatPreviewObjects.length || 
@@ -165,7 +166,7 @@ export class StadiumManagerSeat {
           this.stadiumManager.lastSeatColor = seatOptions.color;
           this.stadiumManager.lastPreviewCount = availablePositions.length;
           
-          console.log(`🪑 Created ${this.stadiumManager.seatPreviewObjects.length} preview seats for ${seatOptions.placementMode} mode`);
+          logger.debug(`🪑 Created ${this.stadiumManager.seatPreviewObjects.length} preview seats for ${seatOptions.placementMode} mode`);
         } else {
           // Jen aktualizuj pozice existujících preview objektů
           availablePositions.forEach((seatPos, index) => {
@@ -236,19 +237,19 @@ export class StadiumManagerSeat {
     this.stadiumManager.lastPreviewCount = 0;
     
     if (this.stadiumManager.seatPreviewObjects.length === 0) {
-      console.log(`🧹 All seat previews cleared`);
+      logger.debug(`🧹 All seat previews cleared`);
     }
   }
 
   // 🔥 Přidání sedaček na schody s POKROČILOU LOGIKOU pro všechny módy
   addSeatsToStairs(targetStairs, intersectionPoint, seatOptions, stadiumElements, setStadiumElements, seatPrice = null) {
-    console.log(`🔥🔥🔥 addSeatsToStairs ENTRY POINT:`);
-    console.log(`🔥 targetStairs:`, targetStairs?.id || 'null');
-    console.log(`🔥 seatOptions RAW:`, seatOptions);
-    console.log(`🔥 seatOptions.type = "${seatOptions?.type}", seatOptions.color = "${seatOptions?.color}", placementMode = "${seatOptions?.placementMode}"`);
+    logger.debug(`🔥🔥🔥 addSeatsToStairs ENTRY POINT:`);
+    logger.debug(`🔥 targetStairs:`, targetStairs?.id || 'null');
+    logger.debug(`🔥 seatOptions RAW:`, seatOptions);
+    logger.debug(`🔥 seatOptions.type = "${seatOptions?.type}", seatOptions.color = "${seatOptions?.color}", placementMode = "${seatOptions?.placementMode}"`);
     
     const { placementMode, type, color } = seatOptions;
-    console.log(`🪑 Destructured options: placementMode=${placementMode}, type=${type}, color=${color}`);
+    logger.debug(`🪑 Destructured options: placementMode=${placementMode}, type=${type}, color=${color}`);
     
     let seatsToAdd = [];
     
@@ -258,9 +259,9 @@ export class StadiumManagerSeat {
         const nearestSeatPos = StadiumBuilder.findNearestSeatPosition(intersectionPoint, targetStairs);
         if (nearestSeatPos && !this.isPositionOccupied(nearestSeatPos.position, stadiumElements)) {
           seatsToAdd = [nearestSeatPos];
-          console.log(`🪑 Single mode: Adding 1 seat at step ${nearestSeatPos.stepIndex}`);
+          logger.debug(`🪑 Single mode: Adding 1 seat at step ${nearestSeatPos.stepIndex}`);
         } else {
-          console.log(`🪑 Single mode: Position occupied or invalid`);
+          logger.debug(`🪑 Single mode: Position occupied or invalid`);
         }
         break;
         
@@ -274,7 +275,7 @@ export class StadiumManagerSeat {
           // Vyfiltruj pozice kde už sedačky jsou
           seatsToAdd = rowPositions.filter(pos => !this.isPositionOccupied(pos.position, stadiumElements));
           
-          console.log(`🪑 Row mode: Step ${targetSeatPos.stepIndex} - ${rowPositions.length} total positions, ${seatsToAdd.length} available`);
+          logger.debug(`🪑 Row mode: Step ${targetSeatPos.stepIndex} - ${rowPositions.length} total positions, ${seatsToAdd.length} available`);
         }
         break;
         
@@ -285,20 +286,20 @@ export class StadiumManagerSeat {
         // Vyfiltruj pozice kde už sedačky jsou
         seatsToAdd = allPositions.filter(pos => !this.isPositionOccupied(pos.position, stadiumElements));
         
-        console.log(`🪑 All mode: ${allPositions.length} total positions, ${seatsToAdd.length} available`);
+        logger.debug(`🪑 All mode: ${allPositions.length} total positions, ${seatsToAdd.length} available`);
         break;
         
       default:
-        console.error(`❌ Unknown placement mode: ${placementMode}`);
+        logger.error(`❌ Unknown placement mode: ${placementMode}`);
         return;
     }
     
     if (seatsToAdd.length === 0) {
-      console.log(`🪑 No seats to add - all positions occupied or invalid`);
+      logger.debug(`🪑 No seats to add - all positions occupied or invalid`);
       return;
     }
     
-    console.log(`🪑 Creating ${seatsToAdd.length} seats with type=${type}, color=${color}`);
+    logger.debug(`🪑 Creating ${seatsToAdd.length} seats with type=${type}, color=${color}`);
     
     // Vytvoř všechny sedačky
     const newSeats = [];
@@ -333,7 +334,7 @@ export class StadiumManagerSeat {
     // Přidej všechny nové sedačky do state najednou
     if (newSeats.length > 0) {
       setStadiumElements(prev => [...prev, ...newSeats]);
-      console.log(`✅ Added ${newSeats.length} ${type} (${color}) seats in ${placementMode} mode`);
+      logger.debug(`✅ Added ${newSeats.length} ${type} (${color}) seats in ${placementMode} mode`);
     }
   }
 }

--- a/src/StadiumManager/StadiumManagerSelection.js
+++ b/src/StadiumManager/StadiumManagerSelection.js
@@ -1,5 +1,6 @@
 // src/StadiumManager/StadiumManagerSelection.js - 🎯 SELECTION SYSTEM
 import { THREE } from '../three.js';
+import * as logger from '../utils/logger.js';
 
 export class StadiumManagerSelection {
   constructor(stadiumManager) {
@@ -30,7 +31,7 @@ export class StadiumManagerSelection {
       this.stadiumManager.scene.add(glowHelper);
       this.stadiumManager.selectedGlow = glowHelper;
       
-      console.log(`🟠 Orange outline created for ${selectedObject.type}`);
+      logger.debug(`🟠 Orange outline created for ${selectedObject.type}`);
     }
   }
 
@@ -61,7 +62,7 @@ export class StadiumManagerSelection {
       this.stadiumManager.scene.add(glowHelper);
       this.stadiumManager.selectedGlow = glowHelper;
       
-      console.log(`🟠 Orange outline updated for ${selectedObject.type}`);
+      logger.debug(`🟠 Orange outline updated for ${selectedObject.type}`);
     }
   }
 

--- a/src/StadiumManager/StadiumManagerTerrain.js
+++ b/src/StadiumManager/StadiumManagerTerrain.js
@@ -1,5 +1,6 @@
 // src/StadiumManager/StadiumManagerTerrain.js - 🎨 TERRAIN PAINTING SYSTEM
 import { THREE } from '../three.js';
+import * as logger from '../utils/logger.js';
 
 export class StadiumManagerTerrain {
   constructor(stadiumManager) {

--- a/src/StadiumManager/StadiumManagerUtility.js
+++ b/src/StadiumManager/StadiumManagerUtility.js
@@ -1,5 +1,6 @@
 // src/StadiumManager/StadiumManagerUtility.js - 🛠️ UTILITY FUNCTIONS
 import { StadiumBuilder } from '../StadiumBuilder.js';
+import * as logger from '../utils/logger.js';
 
 export class StadiumManagerUtility {
   constructor(stadiumManager) {
@@ -20,11 +21,11 @@ export class StadiumManagerUtility {
         mesh = this.stadiumManager.terrain.createAccumulatedTerrain(element.position, element.currentHeight || 0, element.type);
         this.stadiumManager.terrainMeshes.set(element.gridKey, mesh);
         
-        console.log(`🎨 Restored terrain brush: ${element.type} at ${element.gridKey} with height ${element.currentHeight}m`);
+        logger.debug(`🎨 Restored terrain brush: ${element.type} at ${element.gridKey} with height ${element.currentHeight}m`);
       }
       // 🪑 SPECIÁLNÍ HANDLING pro sedačky - použij uložené options
       else if (element.type === 'individual_seat') {
-        console.log(`🪑 Recreating existing seat with saved options:`, {
+        logger.debug(`🪑 Recreating existing seat with saved options:`, {
           seatType: element.seatType || 'plastic',
           seatColor: element.seatColor || 'blue',
           position: element.position
@@ -79,7 +80,7 @@ export class StadiumManagerUtility {
     // 🪑 Vymaž i seat preview
     this.stadiumManager.seat.clearSeatPreview();
     
-    console.log(`🎨 Cleared all stadium elements and terrain data`);
+    logger.debug(`🎨 Cleared all stadium elements and terrain data`);
   }
 
   // Complete disposal of all resources

--- a/src/StadiumManager/StadiumManagerValidation.js
+++ b/src/StadiumManager/StadiumManagerValidation.js
@@ -1,5 +1,6 @@
 // src/StadiumManager/StadiumManagerValidation.js - 🌍 VALIDATION SYSTEM
 
+import * as logger from '../utils/logger.js';
 export class StadiumManagerValidation {
     constructor(stadiumManager) {
       this.stadiumManager = stadiumManager;

--- a/src/utils/logger.js
+++ b/src/utils/logger.js
@@ -1,0 +1,30 @@
+/**
+ * Centralized logger. Debug messages appear only when NODE_ENV is not
+ * 'production' or when the DEBUG environment variable is set to 'true'.
+ *
+ * Usage:
+ *   import * as logger from './utils/logger.js';
+ *   logger.info('hello');
+ *   logger.debug('details'); // shown only in debug mode
+ */
+const isDebug = process.env.DEBUG === 'true' || process.env.NODE_ENV !== 'production';
+
+export function debug(...args) {
+  if (isDebug) {
+    console.debug(...args);
+  }
+}
+
+export function info(...args) {
+  console.info(...args);
+}
+
+export function warn(...args) {
+  console.warn(...args);
+}
+
+export function error(...args) {
+  console.error(...args);
+}
+
+export default { debug, info, warn, error };


### PR DESCRIPTION
## Summary
- add centralized logger with environment-controlled debug output
- swap direct console.log usage for logger in core gameplay and stadium modules
- document enabling debug logs in README

## Testing
- `npm test -- --watchAll=false --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_6891f2c557c48323ac3266b0169798ef