### PR TITLE
Fix daily reward persistence and add monthly preview

### DIFF
--- a/src/PlayerDataManagerEconomy.js
+++ b/src/PlayerDataManagerEconomy.js
@@ -9,7 +9,12 @@ export class PlayerEconomyManager {
       this.realMoneyBalance = 0;     // Skutečný zůstatek v CZK
       
       // 🎁 Daily rewards tracker
-      this.dailyRewards = {
+      // Načti uložený stav z localStorage, aby se po F5 nezresetoval
+      const savedRewards = typeof window !== 'undefined'
+        ? JSON.parse(localStorage.getItem('dailyRewards') || 'null')
+        : null;
+
+      this.dailyRewards = savedRewards || {
         lastClaim: null,
         streak: 0,
         nextReward: 500000       // 🚀 Vyšší denní odměny pro bohaté hráče!
@@ -88,7 +93,8 @@ export class PlayerEconomyManager {
         
         // Check if streak continues (claimed within 48 hours)
         if (hoursSinceLastClaim <= 48) {
-          this.dailyRewards.streak++;
+          // 30denní cyklus - po 30 dnech se vrátí na den 1
+          this.dailyRewards.streak = (this.dailyRewards.streak % 30) + 1;
         } else {
           this.dailyRewards.streak = 1;
         }
@@ -116,6 +122,11 @@ export class PlayerEconomyManager {
       
       this.dailyRewards.lastClaim = now;
       this.dailyRewards.nextReward = baseReward + Math.min((this.dailyRewards.streak + 1) * 100000, 2000000);
+
+      // Ulož stav do localStorage, aby se po restartu zachoval
+      if (typeof window !== 'undefined') {
+        localStorage.setItem('dailyRewards', JSON.stringify(this.dailyRewards));
+      }
       
       this.addCoins(totalReward, `Daily reward (${this.dailyRewards.streak} day streak)`);
       if (gemReward > 0) {
@@ -224,8 +235,23 @@ export class PlayerEconomyManager {
       this.virtualCoins = data.virtualCoins ?? this.virtualCoins;
       this.premiumGems = data.premiumGems ?? this.premiumGems;
       this.realMoneyBalance = data.realMoneyBalance ?? this.realMoneyBalance;
-      this.dailyRewards = { ...this.dailyRewards, ...data.dailyRewards };
-      
+      if (data.dailyRewards) {
+        const localLast = this.dailyRewards.lastClaim ? new Date(this.dailyRewards.lastClaim) : null;
+        const remoteLast = data.dailyRewards.lastClaim ? new Date(data.dailyRewards.lastClaim) : null;
+
+        // Ponech si novější záznam - nevracej se k starším odměnám
+        if (remoteLast && (!localLast || remoteLast > localLast)) {
+          this.dailyRewards = { ...this.dailyRewards, ...data.dailyRewards };
+        } else {
+          this.dailyRewards = { ...data.dailyRewards, ...this.dailyRewards };
+        }
+      }
+
+      // Aktualizuj localStorage, aby se data zachovala mezi relacemi
+      if (typeof window !== 'undefined') {
+        localStorage.setItem('dailyRewards', JSON.stringify(this.dailyRewards));
+      }
+
       this._coinFormatted = this.virtualCoins.toLocaleString('cs-CZ');
     }
     

--- a/src/PlayerInfoPanel.jsx
+++ b/src/PlayerInfoPanel.jsx
@@ -24,6 +24,16 @@ export const PlayerInfoPanel = ({ onCustomizeClick }) => {
     coachLevel: playerDataManager.training.coachLevel
   });
 
+  const monthlyRewards = Array.from({ length: 30 }, (_, i) => {
+    const day = i + 1;
+    const baseReward = 500000;
+    const streakBonus = Math.min(day * 100000, 2000000);
+    const coins = baseReward + streakBonus;
+    const gems = day % 7 === 0 ? 5 * Math.floor(day / 7) : 0;
+    const training = day % 3 === 0 ? 1 : 0;
+    return { day, coins, gems, training };
+  });
+
   // Získej top 3 atributy hráče
   function getTopAttributes() {
     const allAttributes = [];
@@ -185,7 +195,7 @@ export const PlayerInfoPanel = ({ onCustomizeClick }) => {
     const updateData = () => {
       setPlayerData(playerDataManager.getPlayerSummary());
       setMoneyFormat(playerDataManager.getFormattedMoney());
-      
+
       setPlayerRatings({
         overall: playerDataManager.getOverallRating(),
         position: playerDataManager.getPositionRating('CAM'),
@@ -196,6 +206,9 @@ export const PlayerInfoPanel = ({ onCustomizeClick }) => {
         focus: playerDataManager.training.focus,
         coachLevel: playerDataManager.training.coachLevel
       });
+
+      // Po načtení dat znovu ověř denní odměnu
+      checkDailyReward();
     };
 
     playerDataManager.addEventListener('coinsChanged', updateData);
@@ -808,10 +821,24 @@ export const PlayerInfoPanel = ({ onCustomizeClick }) => {
         }}>
           <div style={{ marginBottom: '4px' }}>🎁 Denní odměna za {rewardCooldown}h</div>
           <div style={{ fontSize: '10px', opacity: 0.7 }}>
-            Streak: {playerDataManager.dailyRewards.streak} dní
+          Streak: {playerDataManager.dailyRewards.streak} dní
           </div>
         </div>
       )}
+
+      {/* Měsíční přehled odměn */}
+      <details style={{ marginTop: '10px', fontSize: '12px', color: '#ccc' }}>
+        <summary style={{ cursor: 'pointer' }}>📅 Odměny na 30 dní</summary>
+        <ul style={{ listStyle: 'none', padding: 0, margin: '5px 0', maxHeight: '150px', overflowY: 'auto' }}>
+          {monthlyRewards.map(r => (
+            <li key={r.day} style={{ marginBottom: '2px' }}>
+              Den {r.day}: 🪙 +{r.coins}
+              {r.training > 0 && <span> 🏋️ +{r.training}</span>}
+              {r.gems > 0 && <span> 💎 +{r.gems}</span>}
+            </li>
+          ))}
+        </ul>
+      </details>
 
       {/* Quick Training Reminder */}
       {trainingInfo.dailyPoints > 0 && (


### PR DESCRIPTION
## Summary
- keep newer local daily reward data instead of overwriting with older remote data
- show 30-day reward schedule in the player info panel

## Testing
- `npm test -- --watchAll=false` *(fails: No tests found)*

------
https://chatgpt.com/codex/tasks/task_e_6891e6afcbe88323b554eca63e1c2a2e